### PR TITLE
Fix for PHP 7 compatibility

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -889,7 +889,7 @@ function parse_out($output, $check = FALSE)
 		{
 			$data_exp = explode(' ', trim($summary_part), 3);
 
-			$summary_part = preg_replace("/bgp-as-path=\"([^\"]+)\"/ex", "stripslashes('bgp-as-path=\"'.link_as('\\1').'\"')", $summary_part);
+			$summary_part = preg_replace_callback("/bgp-as-path=\"([^\"]+)\"/x", function ($matches) { return stripslashes("bgp-as-path='".link_as($matches[1])."'"); }, $summary_part);
 
 			if (strpos($data_exp[1], 'A') !== FALSE)
 			{
@@ -907,7 +907,7 @@ function parse_out($output, $check = FALSE)
 	// MikroTik
 	if (preg_match("/^\/routing bgp advertisements print/i", $exec) AND $os == 'mikrotik')
 	{
-		return preg_replace("/^(.{8}\s)([\d\.A-Fa-f:\/]+)(\s+)/e", '"\\1".link_command("bgp", "\\2")."\\3"', $output);
+		return preg_replace_callback("/^(.{8}\s)([\d\.A-Fa-f:\/]+)(\s+)/", function ($matches) { return $matches[1].link_command("bgp", $matches[2]).$matches[3]; }, $output);
 	}
 
 	// MikroTik


### PR DESCRIPTION
Problem: with PHP 7 showing some BGP info and routes does not work with such message in error.log:

[client 10.0.0.213:51788] AH01071: Got error 'PHP message: PHP Warning:  preg_replace(): The /e modifier is no longer supported, use preg_replace_callback instead in /var/www/lg/htdocs/index.php on line 914\n'

Proposed fix:

Replace call of preg_replace with unsupported modifier with preg_replace_callback
in Mikrotik section

Unfortunately i can not test similar fixes for other router types(because i did not have them), so i did work only for Mikrotik related stuff