### PR TITLE
fixing command for latest ROS6

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -184,7 +184,7 @@ $queries = array
 	(
 		'ipv4' => array
 		(
-			'bgp' => '/ip route print detail where dst-address=%s',
+			'bgp' => '/ip route print detail where bgp dst-address=%s',
 			'advertised-routes'	=> '/routing bgp advertisements print peer=%s',
 			'routes' => '/ip route print where gateway=%s',
 			'summary' => '/routing bgp peer print status where address-families=ip',
@@ -193,7 +193,7 @@ $queries = array
 		),
 		'ipv6' => array
 		(
-			'bgp' => '/ipv6 route print detail where dst-address=%s',
+			'bgp' => '/ipv6 route print detail where bgp dst-address=%s',
 			'advertised-routes'	=> '/routing bgp advertisements print peer=%s',
 			'routes' => '/ipv6 route print where gateway=%s',
 			'summary' => '/routing bgp peer print status where address-families=ipv6',


### PR DESCRIPTION
The original command wasn't working for us, and when checking syntax it appeared to be missing the **bgp** tag.

Additionally my network guy says a better command is

```
/ip route print detail where bgp %s in dst-address
```
where %s is an ip address, not a range. This provides more output by giving all the advertisements given by all peers.