### PR TITLE
removing slash from ping and traceroute for mikrotik

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -188,8 +188,8 @@ $queries = array
 			'advertised-routes'	=> '/routing bgp advertisements print peer=%s',
 			'routes' => '/ip route print where gateway=%s',
 			'summary' => '/routing bgp peer print status where address-families=ip',
-			'ping' => '/ping count=5 size=56 %s',
-			'trace' => '/tool traceroute %s size=60 count=1',
+			'ping' => 'ping count=5 size=56 %s',
+			'trace' => 'tool traceroute %s size=60 count=1',
 		),
 		'ipv6' => array
 		(
@@ -197,8 +197,8 @@ $queries = array
 			'advertised-routes'	=> '/routing bgp advertisements print peer=%s',
 			'routes' => '/ipv6 route print where gateway=%s',
 			'summary' => '/routing bgp peer print status where address-families=ipv6',
-			'ping' => '/ping count=5 size=56 %s',
-			'trace' => '/tool traceroute %s size=60 count=1',
+			'ping' => 'ping count=5 size=56 %s',
+			'trace' => 'tool traceroute %s size=60 count=1',
 		)
 	),
 	'junos' => array


### PR DESCRIPTION
As per https://github.com/hsdn/lg/issues/10 I've removed the "/" from "/ping" and "/tool traceroute" to make the output display properly.

Ping works with or without the "/" but traceroute fails when it has the "/". Both work fine without, so leaving both without for consistency. This works on ROS 6. Untested on early versions.